### PR TITLE
fix: Make constructor of hash<long double> delete

### DIFF
--- a/include/hash/hash.hpp
+++ b/include/hash/hash.hpp
@@ -77,35 +77,10 @@ namespace reki
     }
   };
 
-  // from https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/src/c%2B%2B11/hash_c%2B%2B0x.cc
   template <>
   struct hash<long double> final
   {
-    constexpr std::size_t operator()(long double value) const
-    {
-      if (value == 0.0L)
-      {
-        return 0;
-      }
-
-      int exponent;
-
-      value = __builtin_frexpl(value, &exponent);
-
-      value = value < 0.0l ? -(value + 0.5l) : value;
-
-      const long double mult = __SIZE_MAX__ + 1.0l;
-
-      value *= mult;
-
-      const std::size_t hibits = static_cast<std::size_t>(value);
-
-      value = (value - static_cast<long double>(hibits)) * mult;
-
-      const std::size_t coeff = __SIZE_MAX__ / __LDBL_MAX_EXP__;
-
-      return hibits + static_cast<std::size_t>(value) + coeff * exponent;
-    }
+    hash() = delete;
   };
 
   template <typename T>

--- a/test/src/basic_types.cpp
+++ b/test/src/basic_types.cpp
@@ -103,7 +103,7 @@ int main()
 
   "double"_test = [](){ check<double>(); };
 
-  "long double"_test = [](){ check<long double>(); };
+  //"long double"_test = [](){ check<long double>(); };
 
   "nullptr_t"_test = [](){ check<std::nullptr_t>(); };
 


### PR DESCRIPTION
Because the implementation can't be constexpr.